### PR TITLE
Fixed setup.bat

### DIFF
--- a/setup.bat
+++ b/setup.bat
@@ -9,9 +9,9 @@ echo.
 :: Conirmation
 ::
 
-set /P c=Are you sure you want to run the setup? [Y/N]? 
+set /P c=Are you sure you want to run the setup? [y/N]? 
 if /I "%c%" EQU "Y" goto :start 
-if /I "%c%" EQU "N" goto :end
+goto :end
 
 
 ::


### PR DESCRIPTION
If anything other than Y/y or N/n was put in, it would error out trying to execute wget.
I've also made it more obvious what the default option is.