### PR TITLE
Fixed cleanup.bat and changed cleanup.sh

### DIFF
--- a/runtime/linux_scripts/cleanup.sh
+++ b/runtime/linux_scripts/cleanup.sh
@@ -4,7 +4,7 @@ echo MCP Cleanup
 echo -------------
 echo 
 
-read -p 'Are you sure you want to run the cleanup? [Y/N]? ' answer
+read -p 'Are you sure you want to run the cleanup? [y/N]? ' answer
 
 #
 # Methods

--- a/runtime/windows_scripts/cleanup.bat
+++ b/runtime/windows_scripts/cleanup.bat
@@ -9,9 +9,9 @@ echo.
 :: Confirmation
 ::
 
-set /P c=Are you sure you want to run the cleanup? [Y/N]? 
+set /P c=Are you sure you want to run the cleanup? [y/N]? 
 if /I "%c%" EQU "Y" goto :start 
-if /I "%c%" EQU "N" goto :end
+goto :end
 
 ::
 :: Methods


### PR DESCRIPTION
Cleanup.bat had a potentially dangerous bug that could delete a workspace if input was anything but "N" or "n".

Both files are now more obvious about what the default option is.

I reccomend merging ASAP after testing to prevent data loss.